### PR TITLE
refactor: update testcase schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ smoker -testsuite smoke-api.json
 Using docker image:
 
 ```bash
-docker run --rm -v $(PWD):/data stunt/smoker:latest -testsuite /data/smoke-api.json
+docker run --rm -v $(PWD):/data stunt/smoker -testsuite /data/smoke-api.json
 ```
 
 Run with 15 workers and set global timeout to 5 seconds:
@@ -111,7 +111,7 @@ A test case can have all the following parameters to give you more control on wh
           "github",
           "[a-z]"
         ],
-        "header": {
+        "headers": {
           "Content-Type": "application/json"
         }
       }
@@ -183,7 +183,7 @@ Example:
           "Page not found",
           "[a-z]"
         ],
-        "header": {
+        "headers": {
           "Content-Type": "application/json",
           "X-Requestid": "*"
         }

--- a/core/contracts.go
+++ b/core/contracts.go
@@ -37,5 +37,5 @@ type TestCase struct {
 type Assertions struct {
 	StatusCode int               `json:"statusCode"`
 	Body       []string          `json:"body"`
-	Header     map[string]string `json:"header"`
+	Headers    map[string]string `json:"headers"`
 }

--- a/examples/example-smoketestsuite.json
+++ b/examples/example-smoketestsuite.json
@@ -1,0 +1,36 @@
+{
+  "tests": [
+    {
+      "name": "Github.com is live",
+      "url": "https://github.com"
+    },
+    {
+      "name": "Github.com about shows copyright notice",
+      "url": "https://github.com/about",
+      "assertions": {
+        "body": [
+          "&copy; [0-9]{4} GitHub, Inc\\."
+        ]
+      }
+    },
+    {
+      "name": "Github repos API does not accept POST request",
+      "url": "https://api.github.com/repos/amad/smoker",
+      "method": "post",
+      "headers": {
+        "Accept": "application/json"
+      },
+      "assertions": {
+        "statusCode": 404
+      }
+    },
+    {
+      "name": "Github fetch user. This fails without valid token",
+      "url": "https://api.github.com/user",
+      "method": "post",
+      "headers": {
+        "Authorization": "token GITHUB_TOKEN_PLACEHOLDER"
+      }
+    }
+  ]
+}

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -97,8 +97,8 @@ func (r *Requester) Request(tc core.TestCase) (bool, error) {
 		}
 	}
 
-	if len(tc.Assertions.Header) != 0 {
-		for expectedHeaderName, expectedHeaderValue := range tc.Assertions.Header {
+	if len(tc.Assertions.Headers) != 0 {
+		for expectedHeaderName, expectedHeaderValue := range tc.Assertions.Headers {
 			canonicalHeaderName := textproto.CanonicalMIMEHeaderKey(expectedHeaderName)
 
 			headerValue, foundHeader := res.Header[canonicalHeaderName]

--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -122,7 +122,7 @@ func TestRequest(t *testing.T) {
 				Name: "test",
 				URL:  "example.com",
 				Assertions: core.Assertions{
-					Header: map[string]string{"Content-Type": "application/json"},
+					Headers: map[string]string{"Content-Type": "application/json"},
 				},
 			},
 			mockStatusCode: 200,
@@ -135,7 +135,7 @@ func TestRequest(t *testing.T) {
 				Name: "test",
 				URL:  "example.com",
 				Assertions: core.Assertions{
-					Header: map[string]string{"Content-Type": "application/json"},
+					Headers: map[string]string{"Content-Type": "application/json"},
 				},
 			},
 			mockStatusCode: 200,
@@ -147,7 +147,7 @@ func TestRequest(t *testing.T) {
 				Name: "test",
 				URL:  "example.com",
 				Assertions: core.Assertions{
-					Header: map[string]string{"access-control-allow-origin": "*", "content-length": "[0-9]+"},
+					Headers: map[string]string{"access-control-allow-origin": "*", "content-length": "[0-9]+"},
 				},
 			},
 			mockStatusCode: 200,


### PR DESCRIPTION
Renamed `assertions.header` to `assertions.headers` to keep it consistent with request headers.